### PR TITLE
feat(chat): add document-scoped chat via documentPaths parameter

### DIFF
--- a/server/endpoints/api/workspace/index.js
+++ b/server/endpoints/api/workspace/index.js
@@ -704,6 +704,8 @@ function apiWorkspaceEndpoints(app) {
         await EventLogs.logEvent("api_sent_chat", {
           workspaceName: workspace?.name,
           chatModel: workspace?.chatModel || "System Default",
+          documentPaths: documentPaths || null,
+          scopeType: documentPaths && documentPaths.length > 0 && !documentPaths.includes("*") ? "document-scoped" : "full-workspace",
         });
         return response.status(200).json({ ...result });
       } catch (e) {
@@ -859,6 +861,8 @@ function apiWorkspaceEndpoints(app) {
         await EventLogs.logEvent("api_sent_chat", {
           workspaceName: workspace?.name,
           chatModel: workspace?.chatModel || "System Default",
+          documentPaths: documentPaths || null,
+          scopeType: documentPaths && documentPaths.length > 0 && !documentPaths.includes("*") ? "document-scoped" : "full-workspace",
         });
         response.end();
       } catch (e) {

--- a/server/endpoints/api/workspace/index.js
+++ b/server/endpoints/api/workspace/index.js
@@ -600,7 +600,7 @@ function apiWorkspaceEndpoints(app) {
    #swagger.tags = ['Workspaces']
    #swagger.description = 'Execute a chat with a workspace'
    #swagger.requestBody = {
-       description: 'Send a prompt to the workspace and the type of conversation (query or chat).<br/><b>Query:</b> Will not use LLM unless there are relevant sources from vectorDB & does not recall chat history.<br/><b>Chat:</b> Uses LLM general knowledge w/custom embeddings to produce output, uses rolling chat history.',
+       description: 'Send a prompt to the workspace and the type of conversation (query or chat).<br/><b>Query:</b> Will not use LLM unless there are relevant sources from vectorDB & does not recall chat history.<br/><b>Chat:</b> Uses LLM general knowledge w/custom embeddings to produce output, uses rolling chat history.<br/><b>documentPaths:</b> Optional array of document paths to scope the chat to specific documents. If provided (and does not contain "*"), only those documents will be used, vector search will be skipped, and pinned documents will be ignored. Use ["*"] or omit for full workspace scope.',
        required: true,
        content: {
          "application/json": {
@@ -608,6 +608,7 @@ function apiWorkspaceEndpoints(app) {
              message: "What is AnythingLLM?",
              mode: "query | chat",
              sessionId: "identifier-to-partition-chats-by-external-id",
+             documentPaths: ["custom-documents/doc1.json", "custom-documents/doc2.json"],
              attachments: [
                {
                  name: "image.png",
@@ -651,6 +652,7 @@ function apiWorkspaceEndpoints(app) {
           sessionId = null,
           attachments = [],
           reset = false,
+          documentPaths = null,
         } = reqBody(request);
         const workspace = await Workspace.get({ slug: String(slug) });
 
@@ -689,6 +691,7 @@ function apiWorkspaceEndpoints(app) {
           sessionId: !!sessionId ? String(sessionId) : null,
           attachments,
           reset,
+          documentPaths,
         });
 
         await Telemetry.sendTelemetry("sent_chat", {
@@ -725,7 +728,7 @@ function apiWorkspaceEndpoints(app) {
    #swagger.tags = ['Workspaces']
    #swagger.description = 'Execute a streamable chat with a workspace'
    #swagger.requestBody = {
-       description: 'Send a prompt to the workspace and the type of conversation (query or chat).<br/><b>Query:</b> Will not use LLM unless there are relevant sources from vectorDB & does not recall chat history.<br/><b>Chat:</b> Uses LLM general knowledge w/custom embeddings to produce output, uses rolling chat history.',
+       description: 'Send a prompt to the workspace and the type of conversation (query or chat).<br/><b>Query:</b> Will not use LLM unless there are relevant sources from vectorDB & does not recall chat history.<br/><b>Chat:</b> Uses LLM general knowledge w/custom embeddings to produce output, uses rolling chat history.<br/><b>documentPaths:</b> Optional array of document paths to scope the chat to specific documents. If provided (and does not contain "*"), only those documents will be used, vector search will be skipped, and pinned documents will be ignored. Use ["*"] or omit for full workspace scope.',
        required: true,
        content: {
          "application/json": {
@@ -733,6 +736,7 @@ function apiWorkspaceEndpoints(app) {
              message: "What is AnythingLLM?",
              mode: "query | chat",
              sessionId: "identifier-to-partition-chats-by-external-id",
+             documentPaths: ["custom-documents/doc1.json", "custom-documents/doc2.json"],
              attachments: [
                {
                  name: "image.png",
@@ -797,6 +801,7 @@ function apiWorkspaceEndpoints(app) {
           sessionId = null,
           attachments = [],
           reset = false,
+          documentPaths = null,
         } = reqBody(request);
         const workspace = await Workspace.get({ slug: String(slug) });
 
@@ -842,6 +847,7 @@ function apiWorkspaceEndpoints(app) {
           sessionId: !!sessionId ? String(sessionId) : null,
           attachments,
           reset,
+          documentPaths,
         });
         await Telemetry.sendTelemetry("sent_chat", {
           LLMSelection:

--- a/server/endpoints/api/workspaceThread/index.js
+++ b/server/endpoints/api/workspaceThread/index.js
@@ -465,6 +465,8 @@ function apiWorkspaceThreadEndpoints(app) {
           chatModel: workspace?.chatModel || "System Default",
           threadName: thread?.name,
           userId: user?.id,
+          documentPaths: documentPaths || null,
+          scopeType: documentPaths && documentPaths.length > 0 && !documentPaths.includes("*") ? "document-scoped" : "full-workspace",
         });
         response.status(200).json({ ...result });
       } catch (e) {
@@ -639,6 +641,8 @@ function apiWorkspaceThreadEndpoints(app) {
           chatModel: workspace?.chatModel || "System Default",
           threadName: thread?.name,
           userId: user?.id,
+          documentPaths: documentPaths || null,
+          scopeType: documentPaths && documentPaths.length > 0 && !documentPaths.includes("*") ? "document-scoped" : "full-workspace",
         });
         response.end();
       } catch (e) {

--- a/server/endpoints/api/workspaceThread/index.js
+++ b/server/endpoints/api/workspaceThread/index.js
@@ -356,7 +356,7 @@ function apiWorkspaceThreadEndpoints(app) {
           type: 'string'
       }
       #swagger.requestBody = {
-        description: 'Send a prompt to the workspace thread and the type of conversation (query or chat).',
+        description: 'Send a prompt to the workspace thread and the type of conversation (query or chat).<br/><b>documentPaths:</b> Optional array of document paths to scope the chat to specific documents. If provided (and does not contain "*"), only those documents will be used, vector search will be skipped, and pinned documents will be ignored. Use ["*"] or omit for full workspace scope.',
         required: true,
         content: {
           "application/json": {
@@ -364,6 +364,7 @@ function apiWorkspaceThreadEndpoints(app) {
               message: "What is AnythingLLM?",
               mode: "query | chat",
               userId: 1,
+              documentPaths: ["custom-documents/doc1.json", "custom-documents/doc2.json"],
               attachments: [
                {
                  name: "image.png",
@@ -407,6 +408,7 @@ function apiWorkspaceThreadEndpoints(app) {
           userId,
           attachments = [],
           reset = false,
+          documentPaths = null,
         } = reqBody(request);
         const workspace = await Workspace.get({ slug });
         const thread = await WorkspaceThread.get({
@@ -449,6 +451,7 @@ function apiWorkspaceThreadEndpoints(app) {
           thread,
           attachments,
           reset,
+          documentPaths,
         });
         await Telemetry.sendTelemetry("sent_chat", {
           LLMSelection: process.env.LLM_PROVIDER || "openai",
@@ -498,7 +501,7 @@ function apiWorkspaceThreadEndpoints(app) {
           type: 'string'
       }
       #swagger.requestBody = {
-        description: 'Send a prompt to the workspace thread and the type of conversation (query or chat).',
+        description: 'Send a prompt to the workspace thread and the type of conversation (query or chat).<br/><b>documentPaths:</b> Optional array of document paths to scope the chat to specific documents. If provided (and does not contain "*"), only those documents will be used, vector search will be skipped, and pinned documents will be ignored. Use ["*"] or omit for full workspace scope.',
         required: true,
         content: {
           "application/json": {
@@ -506,6 +509,7 @@ function apiWorkspaceThreadEndpoints(app) {
               message: "What is AnythingLLM?",
               mode: "query | chat",
               userId: 1,
+              documentPaths: ["custom-documents/doc1.json", "custom-documents/doc2.json"],
               attachments: [
                {
                  name: "image.png",
@@ -570,6 +574,7 @@ function apiWorkspaceThreadEndpoints(app) {
           userId,
           attachments = [],
           reset = false,
+          documentPaths = null,
         } = reqBody(request);
         const workspace = await Workspace.get({ slug });
         const thread = await WorkspaceThread.get({
@@ -620,6 +625,7 @@ function apiWorkspaceThreadEndpoints(app) {
           thread,
           attachments,
           reset,
+          documentPaths,
         });
         await Telemetry.sendTelemetry("sent_chat", {
           LLMSelection: process.env.LLM_PROVIDER || "openai",

--- a/server/swagger/openapi.json
+++ b/server/swagger/openapi.json
@@ -2576,6 +2576,10 @@
                 "message": "What is AnythingLLM?",
                 "mode": "query | chat",
                 "sessionId": "identifier-to-partition-chats-by-external-id",
+                "documentPaths": [
+                  "custom-documents/doc1.json",
+                  "custom-documents/doc2.json"
+                ],
                 "attachments": [
                   {
                     "name": "image.png",
@@ -2682,6 +2686,10 @@
                 "message": "What is AnythingLLM?",
                 "mode": "query | chat",
                 "sessionId": "identifier-to-partition-chats-by-external-id",
+                "documentPaths": [
+                  "custom-documents/doc1.json",
+                  "custom-documents/doc2.json"
+                ],
                 "attachments": [
                   {
                     "name": "image.png",
@@ -3474,6 +3482,10 @@
                 "message": "What is AnythingLLM?",
                 "mode": "query | chat",
                 "userId": 1,
+                "documentPaths": [
+                  "custom-documents/doc1.json",
+                  "custom-documents/doc2.json"
+                ],
                 "attachments": [
                   {
                     "name": "image.png",
@@ -3590,6 +3602,10 @@
                 "message": "What is AnythingLLM?",
                 "mode": "query | chat",
                 "userId": 1,
+                "documentPaths": [
+                  "custom-documents/doc1.json",
+                  "custom-documents/doc2.json"
+                ],
                 "attachments": [
                   {
                     "name": "image.png",

--- a/server/utils/DocumentManager/index.js
+++ b/server/utils/DocumentManager/index.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const path = require("path");
-
+const { isWithin, normalizePath } = require("../files");
 const documentsPath =
   process.env.NODE_ENV === "development"
     ? path.resolve(__dirname, `../../storage/documents`)
@@ -73,10 +73,64 @@ class DocumentManager {
       return [];
     }
 
+    // Security: Type validation - ensure all paths are strings
+    if (!docPaths.every((p) => typeof p === "string")) {
+      this.log("Security: Invalid documentPaths - all items must be strings");
+      return [];
+    }
+
+    // Security: Limit array size to prevent DoS
+    const MAX_DOCUMENT_PATHS = 100;
+    if (docPaths.length > MAX_DOCUMENT_PATHS) {
+      this.log(
+        `Security: documentPaths truncated from ${docPaths.length} to ${MAX_DOCUMENT_PATHS} items`
+      );
+      docPaths = docPaths.slice(0, MAX_DOCUMENT_PATHS);
+    }
+
+    // Security: Validate documents belong to this workspace (prevents cross-workspace access)
+    let allowedPaths = new Set();
+    if (this.workspace) {
+      const { Document } = require("../../models/documents");
+      const workspaceDocs = await Document.where({
+        workspaceId: Number(this.workspace.id),
+        docpath: { in: docPaths },
+      });
+      allowedPaths = new Set(workspaceDocs.map((doc) => doc.docpath));
+
+      const blockedCount = docPaths.length - allowedPaths.size;
+      if (blockedCount > 0) {
+        this.log(
+          `Security: Blocked ${blockedCount} documents not belonging to workspace ${this.workspace.slug}`
+        );
+      }
+    }
+
     const scopedDocs = [];
     for await (const docPath of docPaths) {
       try {
-        const filePath = path.resolve(this.documentStoragePath, docPath);
+        // Security: Normalize and validate path to prevent directory traversal
+        const normalizedPath = normalizePath(docPath);
+        const filePath = path.resolve(this.documentStoragePath, normalizedPath);
+
+        // Security: Ensure the resolved path is within the documents directory
+        if (!isWithin(this.documentStoragePath, filePath)) {
+          this.log(
+            `Security: Blocked path traversal attempt - ${docPath} resolves outside storage directory`
+          );
+          continue;
+        }
+
+        // Security: Skip documents not belonging to this workspace
+        if (this.workspace && !allowedPaths.has(docPath)) {
+          continue; // Already logged in batch above
+        }
+
+        if (!fs.existsSync(filePath)) {
+          this.log(`Skipping document - File not found: ${docPath}`);
+          continue;
+        }
+
         const data = JSON.parse(
           fs.readFileSync(filePath, { encoding: "utf-8" })
         );

--- a/server/utils/DocumentManager/index.js
+++ b/server/utils/DocumentManager/index.js
@@ -67,6 +67,45 @@ class DocumentManager {
     );
     return pinnedDocs;
   }
+
+  async docsFromPaths(docPaths) {
+    if (!docPaths || !Array.isArray(docPaths) || docPaths.length === 0) {
+      return [];
+    }
+
+    const scopedDocs = [];
+    for await (const docPath of docPaths) {
+      try {
+        const filePath = path.resolve(this.documentStoragePath, docPath);
+        const data = JSON.parse(
+          fs.readFileSync(filePath, { encoding: "utf-8" })
+        );
+
+        if (
+          !data.hasOwnProperty("pageContent") ||
+          !data.hasOwnProperty("token_count_estimate")
+        ) {
+          this.log(
+            `Skipping document - Could not find page content or token_count_estimate in scoped source: ${docPath}`
+          );
+          continue;
+        }
+
+        // Critical: Do NOT enforce maxTokens check - bypass token limit
+        scopedDocs.push(data);
+      } catch (error) {
+        this.log(
+          `Skipping document - Error loading scoped source: ${docPath}`,
+          error.message
+        );
+      }
+    }
+
+    this.log(
+      `Found ${scopedDocs.length} scoped sources from ${docPaths.length} requested paths.`
+    );
+    return scopedDocs;
+  }
 }
 
 module.exports.DocumentManager = DocumentManager;

--- a/server/utils/chats/apiChatHandler.js
+++ b/server/utils/chats/apiChatHandler.js
@@ -14,6 +14,7 @@ const {
   EphemeralEventListener,
 } = require("../agents/ephemeral");
 const { Telemetry } = require("../../models/telemetry");
+const { EventLogs } = require("../../models/eventLogs");
 
 // Simple toggle-able logger for tracing execution.
 const LOG_ENABLED = process.env.DEBUG_CHAT_HANDLER === "true";
@@ -287,6 +288,23 @@ async function chatSync({
     debugLog(
       `Defined Scope: Using ${scopedDocs.length} scoped documents, skipping vector search and history backfill.`
     );
+
+    // Security: Audit log document-scoped chat access
+    if (documentPaths && documentPaths.length > 0) {
+      await EventLogs.logEvent(
+        "document_scoped_chat",
+        {
+          workspaceId: workspace.id,
+          workspaceName: workspace.name,
+          workspaceSlug: workspace.slug,
+          requestedDocumentPaths: documentPaths,
+          loadedDocumentCount: scopedDocs.length,
+          mode: chatMode,
+          timestamp: new Date().toISOString(),
+        },
+        user?.id || null
+      );
+    }
   }
   debugLog(
     `Assembled ${contextTexts.length} total context chunks for LLM prompt.`
@@ -647,6 +665,23 @@ async function streamChat({
     debugLog(
       `Defined Scope: Using ${scopedDocs.length} scoped documents, skipping vector search and history backfill.`
     );
+
+    // Security: Audit log document-scoped chat access
+    if (documentPaths && documentPaths.length > 0) {
+      await EventLogs.logEvent(
+        "document_scoped_chat",
+        {
+          workspaceId: workspace.id,
+          workspaceName: workspace.name,
+          workspaceSlug: workspace.slug,
+          requestedDocumentPaths: documentPaths,
+          loadedDocumentCount: scopedDocs.length,
+          mode: chatMode,
+          timestamp: new Date().toISOString(),
+        },
+        user?.id || null
+      );
+    }
   }
   debugLog(
     `Assembled ${contextTexts.length} total context chunks for LLM prompt.`

--- a/server/utils/chats/apiChatHandler.js
+++ b/server/utils/chats/apiChatHandler.js
@@ -43,6 +43,7 @@ const debugLog = (...args) => {
  * sessionId: string|null,
  * attachments: { name: string; mime: string; contentString: string }[],
  * reset: boolean,
+ * documentPaths: string[]|null,
  * }} parameters
  * @returns {Promise<ResponseObject>}
  */
@@ -55,6 +56,7 @@ async function chatSync({
   sessionId = null,
   attachments = [],
   reset = false,
+  documentPaths = null,
 }) {
   const uuid = uuidv4();
   const chatMode = mode ?? "chat";
@@ -130,7 +132,9 @@ async function chatSync({
   const hasVectorizedSpace = await VectorDb.hasNamespace(workspace.slug);
   const embeddingsCount = await VectorDb.namespaceCount(workspace.slug);
 
-  if ((!hasVectorizedSpace || embeddingsCount === 0) && chatMode === "query") {
+  // Skip early bailout if documentPaths are provided (we'll use file-based context)
+  const hasDocumentPaths = documentPaths && documentPaths.length > 0 && !documentPaths.includes("*");
+  if ((!hasVectorizedSpace || embeddingsCount === 0) && chatMode === "query" && !hasDocumentPaths) {
     const textResponse =
       workspace?.queryRefusalResponse ??
       "There is no relevant information in this workspace to answer your query.";
@@ -173,79 +177,117 @@ async function chatSync({
     workspace,
     maxTokens: LLMConnector.promptWindowLimit(),
   });
-  const pinnedDocs = await documentManager.pinnedDocs();
-  pinnedDocs.forEach((doc) => {
-    const { pageContent, ...metadata } = doc;
-    pinnedDocIdentifiers.push(sourceIdentifier(doc));
-    contextTexts.push(doc.pageContent);
-    sources.push({
-      text:
-        pageContent.slice(0, 1_000) + "...continued on in source document...",
-      ...metadata,
+
+  // Scope detection: Full Scope if documentPaths is empty, null, or contains "*"
+  const isFullScope =
+    !documentPaths ||
+    documentPaths.length === 0 ||
+    documentPaths.includes("*");
+
+  let vectorSearchResults = {
+    contextTexts: [],
+    sources: [],
+    message: null,
+  };
+  let filledSources = {
+    contextTexts: [],
+    sources: [],
+  };
+
+  if (isFullScope) {
+    // Full Scope Mode: Use pinned docs + vector search + history backfill
+    const pinnedDocs = await documentManager.pinnedDocs();
+    pinnedDocs.forEach((doc) => {
+      const { pageContent, ...metadata } = doc;
+      pinnedDocIdentifiers.push(sourceIdentifier(doc));
+      contextTexts.push(doc.pageContent);
+      sources.push({
+        text:
+          pageContent.slice(0, 1_000) +
+          "...continued on in source document...",
+        ...metadata,
+      });
     });
-  });
 
-  const useHybrid =
-    (process.env.VECTOR_DB === "milvus" ||
-      process.env.VECTOR_DB === "zilliz") &&
-    process.env.EMBEDDING_ENGINE === "hybrid";
-  debugLog("Search strategy", { useHybrid });
+    const useHybrid =
+      (process.env.VECTOR_DB === "milvus" ||
+        process.env.VECTOR_DB === "zilliz") &&
+      process.env.EMBEDDING_ENGINE === "hybrid";
+    debugLog("Search strategy", { useHybrid });
 
-  const vectorSearchResults =
-    embeddingsCount !== 0
-      ? await (useHybrid
-          ? VectorDb.performHybridSearch({
-              namespace: workspace.slug,
-              input: message,
-              LLMConnector,
-              similarityThreshold: workspace?.similarityThreshold,
-              topN: workspace?.topN,
-              filterIdentifiers: pinnedDocIdentifiers,
-              rerank: workspace?.vectorSearchMode === "rerank",
-            })
-          : VectorDb.performSimilaritySearch({
-              namespace: workspace.slug,
-              input: message,
-              LLMConnector,
-              similarityThreshold: workspace?.similarityThreshold,
-              topN: workspace?.topN,
-              filterIdentifiers: pinnedDocIdentifiers,
-              rerank: workspace?.vectorSearchMode === "rerank",
-            }))
-      : {
-          contextTexts: [],
-          sources: [],
-          message: null,
-        };
+    vectorSearchResults =
+      embeddingsCount !== 0
+        ? await (useHybrid
+            ? VectorDb.performHybridSearch({
+                namespace: workspace.slug,
+                input: message,
+                LLMConnector,
+                similarityThreshold: workspace?.similarityThreshold,
+                topN: workspace?.topN,
+                filterIdentifiers: pinnedDocIdentifiers,
+                rerank: workspace?.vectorSearchMode === "rerank",
+              })
+            : VectorDb.performSimilaritySearch({
+                namespace: workspace.slug,
+                input: message,
+                LLMConnector,
+                similarityThreshold: workspace?.similarityThreshold,
+                topN: workspace?.topN,
+                filterIdentifiers: pinnedDocIdentifiers,
+                rerank: workspace?.vectorSearchMode === "rerank",
+              }))
+        : {
+            contextTexts: [],
+            sources: [],
+            message: null,
+          };
 
-  if (vectorSearchResults.message) {
-    return {
-      id: uuid,
-      type: "abort",
-      textResponse: null,
-      sources: [],
-      close: true,
-      error: vectorSearchResults.message,
-      metrics: {},
-    };
+    if (vectorSearchResults.message) {
+      return {
+        id: uuid,
+        type: "abort",
+        textResponse: null,
+        sources: [],
+        close: true,
+        error: vectorSearchResults.message,
+        metrics: {},
+      };
+    }
+
+    const { fillSourceWindow } = require("../helpers/chat");
+    filledSources = fillSourceWindow({
+      nDocs: workspace?.topN || 4,
+      searchResults: vectorSearchResults.sources,
+      history: rawHistory,
+      filterIdentifiers: pinnedDocIdentifiers,
+    });
+
+    // Combine pinned docs + vector search + history backfill
+    contextTexts = [
+      ...contextTexts,
+      ...vectorSearchResults.contextTexts,
+      ...filledSources.contextTexts,
+    ];
+    sources = [...sources, ...vectorSearchResults.sources];
+  } else {
+    // Defined Scope Mode: Use only specified documents, skip vector search and history backfill
+    const scopedDocs = await documentManager.docsFromPaths(documentPaths);
+    scopedDocs.forEach((doc) => {
+      const { pageContent, ...metadata } = doc;
+      pinnedDocIdentifiers.push(sourceIdentifier(doc));
+      contextTexts.push(doc.pageContent);
+      sources.push({
+        text:
+          pageContent.slice(0, 1_000) +
+          "...continued on in source document...",
+        ...metadata,
+      });
+    });
+
+    debugLog(
+      `Defined Scope: Using ${scopedDocs.length} scoped documents, skipping vector search and history backfill.`
+    );
   }
-
-  const { fillSourceWindow } = require("../helpers/chat");
-  const filledSources = fillSourceWindow({
-    nDocs: workspace?.topN || 4,
-    searchResults: vectorSearchResults.sources,
-    history: rawHistory,
-    filterIdentifiers: pinnedDocIdentifiers,
-  });
-
-  // [FIXED] This is the crucial change. We must combine the context from pinned docs,
-  // the current vector search, and the historical search (fillSourceWindow).
-  contextTexts = [
-    ...contextTexts,
-    ...vectorSearchResults.contextTexts,
-    ...filledSources.contextTexts,
-  ];
-  sources = [...sources, ...vectorSearchResults.sources];
   debugLog(
     `Assembled ${contextTexts.length} total context chunks for LLM prompt.`
   );
@@ -347,6 +389,7 @@ async function chatSync({
  * sessionId: string|null,
  * attachments: { name: string; mime: string; contentString: string }[],
  * reset: boolean,
+ * documentPaths: string[]|null,
  * }} parameters
  * @returns {Promise<VoidFunction>}
  */
@@ -360,6 +403,7 @@ async function streamChat({
   sessionId = null,
   attachments = [],
   reset = false,
+  documentPaths = null,
 }) {
   const uuid = uuidv4();
   const chatMode = mode ?? "chat";
@@ -441,7 +485,9 @@ async function streamChat({
   const hasVectorizedSpace = await VectorDb.hasNamespace(workspace.slug);
   const embeddingsCount = await VectorDb.namespaceCount(workspace.slug);
 
-  if ((!hasVectorizedSpace || embeddingsCount === 0) && chatMode === "query") {
+  // Skip early bailout if documentPaths are provided (we'll use file-based context)
+  const hasDocumentPaths = documentPaths && documentPaths.length > 0 && !documentPaths.includes("*");
+  if ((!hasVectorizedSpace || embeddingsCount === 0) && chatMode === "query" && !hasDocumentPaths) {
     const textResponse =
       workspace?.queryRefusalResponse ??
       "There is no relevant information in this workspace to answer your query.";
@@ -490,80 +536,118 @@ async function streamChat({
     workspace,
     maxTokens: LLMConnector.promptWindowLimit(),
   });
-  const pinnedDocs = await documentManager.pinnedDocs();
-  pinnedDocs.forEach((doc) => {
-    const { pageContent, ...metadata } = doc;
-    pinnedDocIdentifiers.push(sourceIdentifier(doc));
-    contextTexts.push(doc.pageContent);
-    sources.push({
-      text:
-        pageContent.slice(0, 1_000) + "...continued on in source document...",
-      ...metadata,
+
+  // Scope detection: Full Scope if documentPaths is empty, null, or contains "*"
+  const isFullScope =
+    !documentPaths ||
+    documentPaths.length === 0 ||
+    documentPaths.includes("*");
+
+  let vectorSearchResults = {
+    contextTexts: [],
+    sources: [],
+    message: null,
+  };
+  let filledSources = {
+    contextTexts: [],
+    sources: [],
+  };
+
+  if (isFullScope) {
+    // Full Scope Mode: Use pinned docs + vector search + history backfill
+    const pinnedDocs = await documentManager.pinnedDocs();
+    pinnedDocs.forEach((doc) => {
+      const { pageContent, ...metadata } = doc;
+      pinnedDocIdentifiers.push(sourceIdentifier(doc));
+      contextTexts.push(doc.pageContent);
+      sources.push({
+        text:
+          pageContent.slice(0, 1_000) +
+          "...continued on in source document...",
+        ...metadata,
+      });
     });
-  });
 
-  const useHybrid =
-    (process.env.VECTOR_DB?.toLowerCase() === "milvus" ||
-      process.env.VECTOR_DB?.toLowerCase() === "zilliz") &&
-    process.env.EMBEDDING_ENGINE?.toLowerCase() === "hybrid";
-  debugLog("Search strategy", { useHybrid });
+    const useHybrid =
+      (process.env.VECTOR_DB?.toLowerCase() === "milvus" ||
+        process.env.VECTOR_DB?.toLowerCase() === "zilliz") &&
+      process.env.EMBEDDING_ENGINE?.toLowerCase() === "hybrid";
+    debugLog("Search strategy", { useHybrid });
 
-  const vectorSearchResults =
-    embeddingsCount !== 0
-      ? await (useHybrid
-          ? VectorDb.performHybridSearch({
-              namespace: workspace.slug,
-              input: message,
-              LLMConnector,
-              similarityThreshold: workspace?.similarityThreshold,
-              topN: workspace?.topN,
-              filterIdentifiers: pinnedDocIdentifiers,
-              rerank: workspace?.vectorSearchMode === "rerank",
-            })
-          : VectorDb.performSimilaritySearch({
-              namespace: workspace.slug,
-              input: message,
-              LLMConnector,
-              similarityThreshold: workspace?.similarityThreshold,
-              topN: workspace?.topN,
-              filterIdentifiers: pinnedDocIdentifiers,
-              rerank: workspace?.vectorSearchMode === "rerank",
-            }))
-      : {
-          contextTexts: [],
-          sources: [],
-          message: null,
-        };
+    vectorSearchResults =
+      embeddingsCount !== 0
+        ? await (useHybrid
+            ? VectorDb.performHybridSearch({
+                namespace: workspace.slug,
+                input: message,
+                LLMConnector,
+                similarityThreshold: workspace?.similarityThreshold,
+                topN: workspace?.topN,
+                filterIdentifiers: pinnedDocIdentifiers,
+                rerank: workspace?.vectorSearchMode === "rerank",
+              })
+            : VectorDb.performSimilaritySearch({
+                namespace: workspace.slug,
+                input: message,
+                LLMConnector,
+                similarityThreshold: workspace?.similarityThreshold,
+                topN: workspace?.topN,
+                filterIdentifiers: pinnedDocIdentifiers,
+                rerank: workspace?.vectorSearchMode === "rerank",
+              }))
+        : {
+            contextTexts: [],
+            sources: [],
+            message: null,
+          };
 
-  if (vectorSearchResults.message) {
-    writeResponseChunk(response, {
-      id: uuid,
-      type: "abort",
-      textResponse: null,
-      sources: [],
-      close: true,
-      error: vectorSearchResults.message,
-      metrics: {},
+    if (vectorSearchResults.message) {
+      writeResponseChunk(response, {
+        id: uuid,
+        type: "abort",
+        textResponse: null,
+        sources: [],
+        close: true,
+        error: vectorSearchResults.message,
+        metrics: {},
+      });
+      return;
+    }
+
+    const { fillSourceWindow } = require("../helpers/chat");
+    filledSources = fillSourceWindow({
+      nDocs: workspace?.topN || 4,
+      searchResults: vectorSearchResults.sources,
+      history: rawHistory,
+      filterIdentifiers: pinnedDocIdentifiers,
     });
-    return;
+
+    // Combine pinned docs + vector search + history backfill
+    contextTexts = [
+      ...contextTexts,
+      ...vectorSearchResults.contextTexts,
+      ...filledSources.contextTexts,
+    ];
+    sources = [...sources, ...vectorSearchResults.sources];
+  } else {
+    // Defined Scope Mode: Use only specified documents, skip vector search and history backfill
+    const scopedDocs = await documentManager.docsFromPaths(documentPaths);
+    scopedDocs.forEach((doc) => {
+      const { pageContent, ...metadata } = doc;
+      pinnedDocIdentifiers.push(sourceIdentifier(doc));
+      contextTexts.push(doc.pageContent);
+      sources.push({
+        text:
+          pageContent.slice(0, 1_000) +
+          "...continued on in source document...",
+        ...metadata,
+      });
+    });
+
+    debugLog(
+      `Defined Scope: Using ${scopedDocs.length} scoped documents, skipping vector search and history backfill.`
+    );
   }
-
-  const { fillSourceWindow } = require("../helpers/chat");
-  const filledSources = fillSourceWindow({
-    nDocs: workspace?.topN || 4,
-    searchResults: vectorSearchResults.sources,
-    history: rawHistory,
-    filterIdentifiers: pinnedDocIdentifiers,
-  });
-
-  // [FIXED] This is the crucial change. We must combine the context from pinned docs,
-  // the current vector search, and the historical search (fillSourceWindow).
-  contextTexts = [
-    ...contextTexts,
-    ...vectorSearchResults.contextTexts,
-    ...filledSources.contextTexts,
-  ];
-  sources = [...sources, ...vectorSearchResults.sources];
   debugLog(
     `Assembled ${contextTexts.length} total context chunks for LLM prompt.`
   );

--- a/system-101-implementation-report.md
+++ b/system-101-implementation-report.md
@@ -12,8 +12,8 @@ Optional `string[]` parameter added to all chat endpoints. When provided (and no
 
 ### Files Modified
 
-- `server/utils/DocumentManager/index.js` - Added `docsFromPaths()` method
-- `server/utils/chats/apiChatHandler.js` - Scope detection logic
+- `server/utils/DocumentManager/index.js` - Added `docsFromPaths()` method with security validations
+- `server/utils/chats/apiChatHandler.js` - Scope detection logic and audit logging
 - `server/endpoints/api/workspace/index.js` - Added param to `/chat` & `/stream-chat`
 - `server/endpoints/api/workspaceThread/index.js` - Added param to thread endpoints
 
@@ -212,7 +212,58 @@ if (docPaths.length > MAX_DOCUMENT_PATHS) {
 }
 ```
 
-#### 4. Workspace Access Control
+#### 4. Document Existence Validation
+**File:** `server/utils/DocumentManager/index.js`
+
+Validates that document files exist before attempting to read them, preventing errors and information disclosure about filesystem structure.
+
+```javascript
+if (!fs.existsSync(filePath)) {
+  this.log(`Skipping document - File not found: ${docPath}`);
+  continue;
+}
+```
+
+#### 5. Audit Logging
+**File:** `server/utils/chats/apiChatHandler.js`
+
+All document-scoped chat access is logged to the `event_logs` table for compliance and security monitoring. This is critical for HIPAA compliance and security auditing.
+
+**Implementation:**
+- Logs are created in both `chatSync()` and `streamChat()` functions
+- Logged after documents are successfully loaded (includes both requested and loaded counts)
+- Uses existing `EventLogs.logEvent()` infrastructure
+
+```javascript
+await EventLogs.logEvent(
+  "document_scoped_chat",
+  {
+    workspaceId: workspace.id,
+    workspaceName: workspace.name,
+    workspaceSlug: workspace.slug,
+    requestedDocumentPaths: documentPaths,
+    loadedDocumentCount: scopedDocs.length,
+    mode: chatMode,
+    timestamp: new Date().toISOString(),
+  },
+  user?.id || null
+);
+```
+
+**Logged Information:**
+- Event type: `"document_scoped_chat"`
+- Workspace: ID, name, and slug
+- Document access: Requested paths and successfully loaded count
+- Context: Chat mode (chat/query) and timestamp
+- User: User ID (or null for system calls)
+
+**Compliance Benefits:**
+- ✅ HIPAA audit trail requirements
+- ✅ Security incident investigation
+- ✅ Access pattern analysis
+- ✅ Compliance reporting
+
+#### 6. Workspace Access Control
 **Handled by:** Keystone via delegated JWT tokens
 
 Workspace access control (ensuring users can only access their assigned workspaces) is enforced upstream by Keystone when creating the delegated JWT token. AnythingLLM trusts the `act.sub` claim in the token.
@@ -235,3 +286,4 @@ Workspace access control (ensuring users can only access their assigned workspac
 | Type confusion (non-string paths) | ✅ Blocked | `typeof` check returns empty |
 | DoS via large array (>100 paths) | ✅ Truncated | Limit to 100 items |
 | Unauthorized workspace access | ✅ Blocked | Keystone delegated JWT |
+| Missing audit trail | ✅ Logged | `EventLogs.logEvent()` for all document-scoped access |

--- a/system-101-implementation-report.md
+++ b/system-101-implementation-report.md
@@ -1,0 +1,237 @@
+# System-101: Document-Scoped Stream Chat
+
+## Summary
+
+Adds **per-request document scoping** to the chat API, allowing users to limit a conversation to specific documents without modifying workspace-level pinned document settings.
+
+## Changes
+
+### New Parameter: `documentPaths`
+
+Optional `string[]` parameter added to all chat endpoints. When provided (and not containing `"*"`), chat uses ONLY the specified documents and skips vector search.
+
+### Files Modified
+
+- `server/utils/DocumentManager/index.js` - Added `docsFromPaths()` method
+- `server/utils/chats/apiChatHandler.js` - Scope detection logic
+- `server/endpoints/api/workspace/index.js` - Added param to `/chat` & `/stream-chat`
+- `server/endpoints/api/workspaceThread/index.js` - Added param to thread endpoints
+
+## Endpoints Updated
+
+- [x] `POST /v1/workspace/:slug/chat`
+- [x] `POST /v1/workspace/:slug/stream-chat`
+- [x] `POST /v1/workspace/:slug/thread/:threadSlug/chat`
+- [x] `POST /v1/workspace/:slug/thread/:threadSlug/stream-chat`
+
+---
+
+## Usage Examples & Expected Results
+
+### Example 1: Defined Scope - Single Document
+
+```json
+{
+  "message": "What condition does the patient have?",
+  "mode": "chat",
+  "documentPaths": ["custom-documents/doc1.pdf-UUID.json"]
+}
+```
+
+| Parameter | Effect |
+|-----------|--------|
+| `documentPaths` with 1 doc | Only that document is used |
+| Vector search | **Skipped** |
+| Pinned docs | **Ignored** |
+
+**Expected Result:** Response `sources` array contains ONLY `doc1.pdf`. LLM answers based solely on that document's content.
+
+---
+
+### Example 2: Defined Scope - Multiple Documents
+
+```json
+{
+  "message": "Compare conditions between patients",
+  "mode": "chat",
+  "documentPaths": [
+    "custom-documents/doc1.pdf-UUID.json",
+    "custom-documents/doc2.pdf-UUID.json"
+  ]
+}
+```
+
+**Expected Result:** Response `sources` contains both doc1 and doc2. LLM can compare information across both documents.
+
+---
+
+### Example 3: Full Scope - Default (No documentPaths)
+
+```json
+{
+  "message": "What patients are in the system?",
+  "mode": "chat"
+}
+```
+
+| Behavior |
+|----------|
+| Pinned documents loaded first |
+| Vector search runs to find relevant chunks |
+| Pinned docs excluded from vector results (deduplication) |
+
+**Expected Result:** Sources include pinned docs + semantically relevant vector search results.
+
+---
+
+### Example 4: Full Scope - Wildcard
+
+```json
+{
+  "message": "What patients are in the system?",
+  "documentPaths": ["*"]
+}
+```
+
+**Expected Result:** Same as Example 3. The `"*"` wildcard explicitly triggers Full Scope.
+
+---
+
+### Example 5: Full Scope - Empty Array
+
+```json
+{
+  "message": "What patients are in the system?",
+  "documentPaths": []
+}
+```
+
+**Expected Result:** Same as Example 3. Empty array treated as Full Scope.
+
+---
+
+### Example 6: Query Mode with documentPaths
+
+```json
+{
+  "message": "What is the diagnosis?",
+  "mode": "query",
+  "documentPaths": ["custom-documents/doc1.pdf-UUID.json"]
+}
+```
+
+**Expected Result:** Query mode works normally with the specified document. Does NOT return "insufficient context" error even if workspace has no embeddings.
+
+---
+
+### Example 7: Thread-Based Chat with documentPaths
+
+```json
+POST /v1/workspace/:slug/thread/:threadSlug/stream-chat
+
+{
+  "message": "What condition does the patient have?",
+  "documentPaths": ["custom-documents/doc1.pdf-UUID.json"]
+}
+```
+
+**Expected Result:** Same scoping behavior as workspace endpoints. Thread history is preserved while document scope is applied.
+
+---
+
+## Parameter Reference
+
+| `documentPaths` Value | Scope Mode | Pinned Docs | Vector Search |
+|-----------------------|------------|-------------|---------------|
+| `null` / not provided | Full | ✅ Used | ✅ Runs |
+| `[]` (empty array) | Full | ✅ Used | ✅ Runs |
+| `["*"]` | Full | ✅ Used | ✅ Runs |
+| `["doc1.json"]` | Defined | ❌ Ignored | ❌ Skipped |
+| `["doc1.json", "doc2.json"]` | Defined | ❌ Ignored | ❌ Skipped |
+
+---
+
+## Testing
+
+| Test | Result |
+|------|--------|
+| Defined scope returns only specified docs | ✅ Pass |
+| Full scope (wildcard) returns pinned + vector | ✅ Pass |
+| Query mode with documentPaths works | ✅ Pass |
+| Thread endpoints support documentPaths | ✅ Pass |
+
+## Security
+
+### Security Fixes Implemented (2026-01-21)
+
+#### 1. Path Traversal Protection
+**File:** `server/utils/DocumentManager/index.js`
+
+Prevents attackers from reading arbitrary files via `documentPaths` like `../../../etc/passwd`. Uses existing `isWithin()` and `normalizePath()` utilities from `server/utils/files/index.js`.
+
+```javascript
+const normalizedPath = normalizePath(docPath);
+const filePath = path.resolve(this.documentStoragePath, normalizedPath);
+
+if (!isWithin(this.documentStoragePath, filePath)) {
+  this.log(`Security: Blocked path traversal attempt - ${docPath}`);
+  continue;
+}
+```
+
+#### 2. Workspace-Level Document Validation
+**File:** `server/utils/DocumentManager/index.js`
+
+Prevents cross-workspace document access. Users can only read documents that belong to their workspace.
+
+```javascript
+const workspaceDocs = await Document.where({
+  workspaceId: Number(this.workspace.id),
+  docpath: { in: docPaths },
+});
+allowedPaths = new Set(workspaceDocs.map((doc) => doc.docpath));
+```
+
+#### 3. Input Validation & DoS Protection
+**File:** `server/utils/DocumentManager/index.js`
+
+- **Type validation:** All `documentPaths` must be strings
+- **DoS protection:** Maximum 100 document paths per request
+
+```javascript
+// Type validation
+if (!docPaths.every((p) => typeof p === "string")) {
+  this.log("Security: Invalid documentPaths - all items must be strings");
+  return [];
+}
+
+// DoS protection
+const MAX_DOCUMENT_PATHS = 100;
+if (docPaths.length > MAX_DOCUMENT_PATHS) {
+  docPaths = docPaths.slice(0, MAX_DOCUMENT_PATHS);
+}
+```
+
+#### 4. Workspace Access Control
+**Handled by:** Keystone via delegated JWT tokens
+
+Workspace access control (ensuring users can only access their assigned workspaces) is enforced upstream by Keystone when creating the delegated JWT token. AnythingLLM trusts the `act.sub` claim in the token.
+
+### Protected Endpoints
+
+| Endpoint | Protections |
+|----------|-------------|
+| `POST /v1/workspace/:slug/chat` | Path traversal, document validation, type/DoS limits |
+| `POST /v1/workspace/:slug/stream-chat` | Path traversal, document validation, type/DoS limits |
+| `POST /v1/workspace/:slug/thread/:threadSlug/chat` | Path traversal, document validation, type/DoS limits |
+| `POST /v1/workspace/:slug/thread/:threadSlug/stream-chat` | Path traversal, document validation, type/DoS limits |
+
+### Attack Vectors Mitigated
+
+| Attack | Status | Implementation |
+|--------|--------|----------------|
+| Path traversal (`../../../etc/passwd`) | ✅ Blocked | `isWithin()` + `normalizePath()` |
+| Cross-workspace document access | ✅ Blocked | `Document.where()` batch validation |
+| Type confusion (non-string paths) | ✅ Blocked | `typeof` check returns empty |
+| DoS via large array (>100 paths) | ✅ Truncated | Limit to 100 items |
+| Unauthorized workspace access | ✅ Blocked | Keystone delegated JWT |


### PR DESCRIPTION
# System-101: Document-Scoped Stream Chat

## Summary

Adds **per-request document scoping** to the chat API, allowing users to limit a conversation to specific documents without modifying workspace-level pinned document settings.

## Changes

### New Parameter: `documentPaths`

Optional `string[]` parameter added to all chat endpoints. When provided (and not containing `"*"`), chat uses ONLY the specified documents and skips vector search.

### Files Modified

- `server/utils/DocumentManager/index.js` - Added `docsFromPaths()` method
- `server/utils/chats/apiChatHandler.js` - Scope detection logic
- `server/endpoints/api/workspace/index.js` - Added param to `/chat` & `/stream-chat`
- `server/endpoints/api/workspaceThread/index.js` - Added param to thread endpoints

## Endpoints Updated

- [x] `POST /v1/workspace/:slug/chat`
- [x] `POST /v1/workspace/:slug/stream-chat`
- [x] `POST /v1/workspace/:slug/thread/:threadSlug/chat`
- [x] `POST /v1/workspace/:slug/thread/:threadSlug/stream-chat`

---

## Usage Examples & Expected Results

### Example 1: Defined Scope - Single Document

```json
{
  "message": "What condition does the patient have?",
  "mode": "chat",
  "documentPaths": ["custom-documents/doc1.pdf-UUID.json"]
}
```

| Parameter | Effect |
|-----------|--------|
| `documentPaths` with 1 doc | Only that document is used |
| Vector search | **Skipped** |
| Pinned docs | **Ignored** |

**Expected Result:** Response `sources` array contains ONLY `doc1.pdf`. LLM answers based solely on that document's content.

---

### Example 2: Defined Scope - Multiple Documents

```json
{
  "message": "Compare conditions between patients",
  "mode": "chat",
  "documentPaths": [
    "custom-documents/doc1.pdf-UUID.json",
    "custom-documents/doc2.pdf-UUID.json"
  ]
}
```

**Expected Result:** Response `sources` contains both doc1 and doc2. LLM can compare information across both documents.

---

### Example 3: Full Scope - Default (No documentPaths)

```json
{
  "message": "What patients are in the system?",
  "mode": "chat"
}
```

| Behavior |
|----------|
| Pinned documents loaded first |
| Vector search runs to find relevant chunks |
| Pinned docs excluded from vector results (deduplication) |

**Expected Result:** Sources include pinned docs + semantically relevant vector search results.

---

### Example 4: Full Scope - Wildcard

```json
{
  "message": "What patients are in the system?",
  "documentPaths": ["*"]
}
```

**Expected Result:** Same as Example 3. The `"*"` wildcard explicitly triggers Full Scope.

---

### Example 5: Full Scope - Empty Array

```json
{
  "message": "What patients are in the system?",
  "documentPaths": []
}
```

**Expected Result:** Same as Example 3. Empty array treated as Full Scope.

---

### Example 6: Query Mode with documentPaths

```json
{
  "message": "What is the diagnosis?",
  "mode": "query",
  "documentPaths": ["custom-documents/doc1.pdf-UUID.json"]
}
```

**Expected Result:** Query mode works normally with the specified document. Does NOT return "insufficient context" error even if workspace has no embeddings.

---

### Example 7: Thread-Based Chat with documentPaths

```json
POST /v1/workspace/:slug/thread/:threadSlug/stream-chat

{
  "message": "What condition does the patient have?",
  "documentPaths": ["custom-documents/doc1.pdf-UUID.json"]
}
```

**Expected Result:** Same scoping behavior as workspace endpoints. Thread history is preserved while document scope is applied.

---

## Parameter Reference

| `documentPaths` Value | Scope Mode | Pinned Docs | Vector Search |
|-----------------------|------------|-------------|---------------|
| `null` / not provided | Full | ✅ Used | ✅ Runs |
| `[]` (empty array) | Full | ✅ Used | ✅ Runs |
| `["*"]` | Full | ✅ Used | ✅ Runs |
| `["doc1.json"]` | Defined | ❌ Ignored | ❌ Skipped |
| `["doc1.json", "doc2.json"]` | Defined | ❌ Ignored | ❌ Skipped |

---

## Testing

| Test | Result |
|------|--------|
| Defined scope returns only specified docs | ✅ Pass |
| Full scope (wildcard) returns pinned + vector | ✅ Pass |
| Query mode with documentPaths works | ✅ Pass |
| Thread endpoints support documentPaths | ✅ Pass |

## Security

- No authentication changes
- `[validatedRequest]` middleware unchanged
- Document paths resolved within storage directory only
